### PR TITLE
fix: get display resolution failed

### DIFF
--- a/src/main/lib/hdc.ts
+++ b/src/main/lib/hdc.ts
@@ -84,7 +84,7 @@ async function getScreen(connectKey: string) {
 
   let physicalResolution = ''
   const physicalResolutionMatch = screen.match(
-    /physical screen resolution: ((\d+)x(\d+))/
+    /powerStatus=(?:POWER_STATUS_ON|POWER_STATUS_SUSPEND).*physical resolution=(\d+x\d+)/
   )
   if (physicalResolutionMatch) {
     physicalResolution = physicalResolutionMatch[1]


### PR DESCRIPTION
fix get display resolution failed.

1. fix regex expression for  `hidumper -s RenderService -a screen` output
```
screen[0]: id=0, powerStatus=POWER_STATUS_OFF, backlight=19651, screenType=EXTERNAL_TYPE, render resolution=1320x2120, physical resolution=1320x2120, isVirtual=false, skipFrameInterval=1, expectedRefreshRate=-1, skipFrameStrategy=0
```

2. add powerStatus=POWER_STATUS_(OFF/ON/SUSPEND) in regex expression to adapt fold display